### PR TITLE
math module import added

### DIFF
--- a/rnaQUAST.py
+++ b/rnaQUAST.py
@@ -5,6 +5,7 @@ __author__ = 'lenk'
 import os
 import sys
 import shutil
+import math
 
 rquast_dirpath = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 


### PR DESCRIPTION
Math variable was used without importing - the script failed with the error 'name "math" is not defined'.